### PR TITLE
test: add invariant test suite for DeFiHub contracts

### DIFF
--- a/test/invariant/GovernanceToken.invariant.t.sol
+++ b/test/invariant/GovernanceToken.invariant.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../../src/GovernanceToken.sol";
+
+/// @dev Exercises GroupStaking with valid (weights == 100) groups so the
+///      stateful invariant fuzzer drives stake/withdraw flows.
+contract GroupStakingHandler is Test {
+    GovernanceToken public token;
+    GroupStaking public staking;
+
+    uint256[] public groupIds;
+    address[] internal members;
+
+    constructor(GovernanceToken token_, GroupStaking staking_) {
+        token = token_;
+        staking = staking_;
+        members = [address(0xA1), address(0xA2), address(0xA3)];
+    }
+
+    function createGroup(uint256 weightSeed) external {
+        uint256[] memory weights = new uint256[](3);
+        // Always sums to 100.
+        weights[0] = bound(weightSeed, 1, 98);
+        weights[1] =
+            bound(uint256(keccak256(abi.encode(weightSeed))), 1, 99 - weights[0]);
+        weights[2] = 100 - weights[0] - weights[1];
+
+        uint256 id = staking.createStakingGroup(members, weights);
+        groupIds.push(id);
+    }
+
+    function stake(uint256 groupSeed, uint256 amount) external {
+        if (groupIds.length == 0) return;
+        uint256 id = groupIds[groupSeed % groupIds.length];
+        amount = bound(amount, 1, 1_000 ether);
+
+        token.mint(address(this), amount);
+        token.approve(address(staking), amount);
+        staking.stakeToGroup(id, amount);
+    }
+
+    function withdraw(uint256 groupSeed, uint256 amount) external {
+        if (groupIds.length == 0) return;
+        uint256 id = groupIds[groupSeed % groupIds.length];
+        (, uint256 total,,) = staking.getGroupInfo(id);
+        if (total == 0) return;
+        staking.withdrawFromGroup(id, bound(amount, 1, total));
+    }
+
+    function groupCount() external view returns (uint256) {
+        return groupIds.length;
+    }
+}
+
+contract GovernanceTokenInvariantTest is Test {
+    GovernanceToken public token;
+    GroupStaking public staking;
+    GroupStakingHandler public handler;
+
+    function setUp() public {
+        token = new GovernanceToken();
+        staking = new GroupStaking(address(token));
+        handler = new GroupStakingHandler(token, staking);
+        targetContract(address(handler));
+    }
+
+    /// GS-G2: every existing group's weights must always sum to exactly 100.
+    /// This is enforced at creation and never mutated, so it holds.
+    function invariant_GS_G2_weightsSumTo100() public view {
+        uint256 count = handler.groupCount();
+        for (uint256 i = 0; i < count; i++) {
+            uint256 id = handler.groupIds(i);
+            (,,, uint256[] memory weights) = staking.getGroupInfo(id);
+            uint256 sum;
+            for (uint256 j = 0; j < weights.length; j++) {
+                sum += weights[j];
+            }
+            assertEq(sum, 100);
+        }
+    }
+
+    // --- Violation proofs (expected-broken invariants) ---
+
+    /// GT-G1: total supply must only grow via an authorized minter.
+    /// `mint` has no access control.
+    function test_GT_G1_anyoneCanMint() public {
+        uint256 before = token.totalSupply();
+        address stranger = address(0xDEAD);
+
+        vm.prank(stranger);
+        token.mint(stranger, 1_000_000 ether);
+
+        assertEq(token.totalSupply(), before + 1_000_000 ether);
+        assertEq(token.balanceOf(stranger), 1_000_000 ether);
+    }
+
+    /// GT-G2: only a privileged admin may change blacklist status.
+    /// `updateUserStatus` is permissionless.
+    function test_GT_G2_anyoneCanBlacklist() public {
+        address victim = address(0xCAFE);
+        address stranger = address(0xDEAD);
+
+        vm.prank(stranger);
+        token.updateUserStatus(victim, true);
+
+        assertTrue(token.blacklisted(victim));
+    }
+
+    /// GS-G1: the staking contract's token balance must equal the sum of all
+    /// group `totalAmount`s. Per-member truncation strands dust that the
+    /// accounting assumes was distributed.
+    function test_GS_G1_withdrawalDustBreaksAccounting() public {
+        address[] memory m = new address[](3);
+        m[0] = address(0xA1);
+        m[1] = address(0xA2);
+        m[2] = address(0xA3);
+        uint256[] memory w = new uint256[](3);
+        w[0] = 34;
+        w[1] = 33;
+        w[2] = 33;
+
+        uint256 id = staking.createStakingGroup(m, w);
+
+        token.approve(address(staking), 100);
+        staking.stakeToGroup(id, 100);
+
+        staking.withdrawFromGroup(id, 99); // distributes 33 + 32 + 32 = 97
+
+        (, uint256 total,,) = staking.getGroupInfo(id);
+        // Accounting says 1 remains; the contract actually holds 3 (dust = 2).
+        assertEq(total, 1);
+        assertEq(token.balanceOf(address(staking)), 3);
+        assertTrue(token.balanceOf(address(staking)) != total);
+    }
+
+    /// GS-F1: a withdrawal must not be permanently blockable by a single
+    /// member's state. Blacklisting one member reverts the whole distribution,
+    /// freezing the group's funds.
+    function test_GS_F1_blacklistedMemberFreezesGroup() public {
+        address[] memory m = new address[](3);
+        m[0] = address(0xA1);
+        m[1] = address(0xA2);
+        m[2] = address(0xA3);
+        uint256[] memory w = new uint256[](3);
+        w[0] = 34;
+        w[1] = 33;
+        w[2] = 33;
+
+        uint256 id = staking.createStakingGroup(m, w);
+        token.approve(address(staking), 100);
+        staking.stakeToGroup(id, 100);
+
+        // Anyone can blacklist a member (see GT-G2).
+        token.updateUserStatus(m[0], true);
+
+        vm.expectRevert(bytes("Recipient is blacklisted"));
+        staking.withdrawFromGroup(id, 100);
+    }
+}

--- a/test/invariant/LiquidityPool.invariant.t.sol
+++ b/test/invariant/LiquidityPool.invariant.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../../src/LiquidityPool.sol";
+
+/// @dev Records the share balance it holds at the moment ETH is received, to
+///      prove the pool transfers ETH before burning shares (LP-F1).
+contract ReentrancyProbe {
+    LiquidityPool public pool;
+    PoolShare public shareToken;
+    uint256 public sharesHeldDuringCallback;
+
+    constructor(LiquidityPool pool_) {
+        pool = pool_;
+        shareToken = pool_.shareToken();
+    }
+
+    function deposit() external payable {
+        pool.deposit{value: msg.value}();
+    }
+
+    function withdrawAll(uint256 shares) external {
+        shareToken.approve(address(pool), shares);
+        pool.withdraw(shares);
+    }
+
+    receive() external payable {
+        sharesHeldDuringCallback = shareToken.balanceOf(address(this));
+    }
+}
+
+/// @notice Executable proofs for the LiquidityPool invariants in INVARIANTS.md.
+///         Every invariant in this section is expected to be VIOLATED on the
+///         current code; each test demonstrates the concrete violation.
+contract LiquidityPoolInvariantTest is Test {
+    LiquidityPool public pool;
+    PoolShare public shareToken;
+
+    uint256 internal constant USER_PK = 0xA11CE;
+    address internal user;
+    address internal attacker = address(0xBEEF);
+    address internal funder = address(0xF00D);
+
+    function setUp() public {
+        // This contract deploys the pool, so it is `owner()` and receives fees.
+        pool = new LiquidityPool();
+        shareToken = pool.shareToken();
+        user = vm.addr(USER_PK);
+    }
+
+    receive() external payable {}
+
+    /// LP-G1: pool ETH must back outstanding shares. Reward claims pay out of
+    /// the same ETH that backs shares, so the pool becomes insolvent.
+    function test_LP_G1_insolventAfterRewardClaim() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        pool.deposit{value: 10 ether}();
+
+        // First deposit mints 1:1, so balance == totalSupply here.
+        assertEq(address(pool).balance, shareToken.totalSupply());
+
+        uint256 amount = pool.rewards(user); // 10% of deposit = 1 ether
+        _claimReward(user, USER_PK, amount, user);
+
+        // Pool paid out reward ETH without burning any shares.
+        assertLt(address(pool).balance, shareToken.totalSupply());
+    }
+
+    /// LP-F1: shares must be burned before ETH leaves the contract.
+    /// The probe still holds its full share balance while it receives ETH.
+    function test_LP_F1_ethSentBeforeSharesBurned() public {
+        ReentrancyProbe probe = new ReentrancyProbe(pool);
+        vm.deal(address(probe), 5 ether);
+        probe.deposit{value: 5 ether}();
+
+        vm.warp(block.timestamp + pool.WITHDRAWAL_DELAY() + 1);
+        probe.withdrawAll(5 ether);
+
+        // CEI violation: shares not yet burned when the ETH callback ran.
+        assertEq(probe.sharesHeldDuringCallback(), 5 ether);
+    }
+
+    /// LP-F3: reward ETH for `user` must only ever reach `user`. The payout
+    /// goes to `msg.sender`, so anyone with a valid signature steals it.
+    function test_LP_F3_rewardRedirectedToCaller() public {
+        vm.deal(user, 10 ether);
+        vm.prank(user);
+        pool.deposit{value: 10 ether}();
+
+        uint256 amount = pool.rewards(user); // 1 ether
+        uint256 attackerBefore = attacker.balance;
+
+        _claimReward(user, USER_PK, amount, attacker);
+
+        // Attacker pocketed the user's reward minus the protocol fee.
+        assertEq(attacker.balance, attackerBefore + (amount - amount / 10));
+    }
+
+    /// LP-F4: every share-minting deposit must arm the withdrawal delay.
+    /// `depositFor` leaves `lastDepositTime` at zero, so the receiver can
+    /// withdraw immediately, bypassing WITHDRAWAL_DELAY.
+    function test_LP_F4_depositForBypassesWithdrawalDelay() public {
+        vm.warp(block.timestamp + 2 days);
+
+        vm.deal(funder, 5 ether);
+        vm.prank(funder);
+        pool.depositFor{value: 5 ether}(user);
+
+        assertEq(pool.lastDepositTime(user), 0);
+
+        vm.startPrank(user);
+        shareToken.approve(address(pool), 5 ether);
+        pool.withdraw(5 ether); // succeeds with no enforced delay for `user`
+        vm.stopPrank();
+
+        assertEq(user.balance, 5 ether);
+    }
+
+    function _claimReward(
+        address rewardUser,
+        uint256 pk,
+        uint256 amount,
+        address caller
+    ) internal {
+        uint256 nonce = pool.nonces(rewardUser);
+        bytes32 messageHash = keccak256(abi.encode(rewardUser, amount, nonce));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, messageHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        vm.prank(caller);
+        pool.claimReward(rewardUser, amount, nonce, signature);
+    }
+}

--- a/test/invariant/StableCoin.invariant.t.sol
+++ b/test/invariant/StableCoin.invariant.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../../src/StableCoin.sol";
+
+/// @dev Drives the TokenStreamer through create/add/withdraw/warp sequences.
+contract StreamerHandler is Test {
+    StableCoin public stablecoin;
+    TokenStreamer public streamer;
+
+    uint256[] public streamIds;
+    address internal recipient = address(0xBEEF);
+
+    constructor(StableCoin stablecoin_, TokenStreamer streamer_) {
+        stablecoin = stablecoin_;
+        streamer = streamer_;
+    }
+
+    function createStream(uint256 amount, uint256 duration) external {
+        amount = bound(amount, 1, 1_000_000);
+        duration = bound(duration, 1 hours, 365 days);
+
+        stablecoin.mint(address(this), amount);
+        stablecoin.approve(address(streamer), amount);
+        uint256 id = streamer.createStream(recipient, amount, duration);
+        streamIds.push(id);
+    }
+
+    function addToStream(uint256 streamSeed, uint256 amount) external {
+        if (streamIds.length == 0) return;
+        uint256 id = streamIds[streamSeed % streamIds.length];
+        (,,,, uint256 endTime,) = streamer.getStreamInfo(id);
+        if (block.timestamp >= endTime) return;
+        amount = bound(amount, 1, 1_000_000);
+
+        stablecoin.mint(address(this), amount);
+        stablecoin.approve(address(streamer), amount);
+        streamer.addToStream(id, amount);
+    }
+
+    function withdraw(uint256 streamSeed) external {
+        if (streamIds.length == 0) return;
+        uint256 id = streamIds[streamSeed % streamIds.length];
+        vm.prank(recipient);
+        try streamer.withdrawFromStream(id) {} catch {}
+    }
+
+    function warp(uint256 secs) external {
+        vm.warp(block.timestamp + bound(secs, 1, 30 days));
+    }
+
+    function streamCount() external view returns (uint256) {
+        return streamIds.length;
+    }
+}
+
+contract StableCoinInvariantTest is Test {
+    StableCoin public stablecoin;
+    TokenStreamer public streamer;
+    StreamerHandler public handler;
+
+    function setUp() public {
+        stablecoin = new StableCoin();
+        streamer = new TokenStreamer(stablecoin);
+        handler = new StreamerHandler(stablecoin, streamer);
+        targetContract(address(handler));
+    }
+
+    /// TS-G2: cumulative withdrawals from a stream never exceed its deposits.
+    function invariant_TS_G2_withdrawnNeverExceedsDeposited() public view {
+        uint256 count = handler.streamCount();
+        for (uint256 i = 0; i < count; i++) {
+            uint256 id = handler.streamIds(i);
+            (, uint256 deposited, uint256 withdrawn,,,) = streamer.getStreamInfo(id);
+            assertLe(withdrawn, deposited);
+        }
+    }
+
+    // --- Violation proofs (expected-broken invariants) ---
+
+    /// SC-G1: stablecoin supply must only grow via an authorized minter.
+    function test_SC_G1_anyoneCanMint() public {
+        uint256 before = stablecoin.totalSupply();
+        address stranger = address(0xDEAD);
+
+        vm.prank(stranger);
+        stablecoin.mint(stranger, 1_000_000);
+
+        assertEq(stablecoin.totalSupply(), before + 1_000_000);
+    }
+
+    /// SC-G2: a whole unit must equal 10**decimals base units consistently.
+    /// `decimals()` returns 1, so integrations assuming 18 mis-scale by 10^17.
+    function test_SC_G2_nonStandardDecimals() public view {
+        assertEq(stablecoin.decimals(), 1);
+        // Constructor minted 1_000_000 whole units -> only 10x in base units.
+        assertEq(stablecoin.totalSupply(), 1_000_000 * 10);
+    }
+
+    /// TS-F1: tokens added mid-stream must vest only over the remaining
+    /// duration. `getAvailableTokens` applies elapsed time to the full
+    /// deposited total, so a top-up is retroactively vested.
+    function test_TS_F1_addToStreamRetroactivelyVests() public {
+        uint256 duration = 1 hours; // 3600s
+        stablecoin.mint(address(this), 7200);
+        stablecoin.approve(address(streamer), 7200);
+
+        uint256 id = streamer.createStream(address(0xBEEF), 3600, duration);
+
+        vm.warp(block.timestamp + 1800); // halfway
+        uint256 availBefore = streamer.getAvailableTokens(id);
+        assertEq(availBefore, 1800); // half of the original 3600 vested
+
+        streamer.addToStream(id, 3600); // total deposited now 7200
+
+        // Newly added tokens should be ~unvested; instead half is available.
+        uint256 availAfter = streamer.getAvailableTokens(id);
+        assertEq(availAfter, 3600);
+        assertEq(availAfter - availBefore, 1800); // 1800 of the top-up vested instantly
+    }
+}


### PR DESCRIPTION
## Invariant test suite

Adds executable Foundry tests under `test/invariant/` that encode the protocol
invariants documented in [`INVARIANTS.md`](../blob/main/INVARIANTS.md). Every
test references its invariant ID so the suite double-checks the spec.

Two kinds of tests:

1. **Stateful invariant fuzzing** (`invariant_*`) on properties that *hold* —
   handler-driven campaigns (128k calls each, 0 reverts) that demonstrate the
   methodology and guard against regressions:
   - `invariant_GS_G2_weightsSumTo100` — group weights always sum to 100
   - `invariant_TS_G2_withdrawnNeverExceedsDeposited` — per-stream conservation

2. **Violation proofs** (`test_<ID>_*`) — deterministic tests that reproduce
   each *broken* invariant from the spec:

   | ID | Demonstrated bug |
   |----|------------------|
   | LP-G1 | Pool insolvent after a reward claim (rewards paid from share-backing ETH) |
   | LP-F1 | `withdraw` sends ETH before burning shares (CEI violation) |
   | LP-F3 | Reward ETH redirected to `msg.sender` instead of the signer |
   | LP-F4 | `depositFor` bypasses `WITHDRAWAL_DELAY` (`lastDepositTime` left 0) |
   | GT-G1 | `GovernanceToken.mint` has no access control |
   | GT-G2 | `updateUserStatus` lets anyone blacklist anyone |
   | GS-G1 | Per-member rounding strands dust, breaking group accounting |
   | GS-F1 | One blacklisted member freezes the whole group withdrawal |
   | SC-G1 | `StableCoin.mint` is permissionless |
   | SC-G2 | `decimals()` returns 1, breaking 18-decimal assumptions |
   | TS-F1 | `addToStream` retroactively vests top-ups against elapsed time |

### Test results

```
Ran 3 test suites: 13 tests passed, 0 failed, 0 skipped (13 total tests)
```

The violation proofs pass by asserting the bug is reproducible — they document
the seeded vulnerabilities. The two `invariant_*` fuzz tests assert properties
that genuinely hold.
